### PR TITLE
fix(numbering): use correct WordprocessingML namespace and remove duplicate bullet num entry

### DIFF
--- a/src/TemplateGen.Core/Services/NumberingDefinitionsGenerator.cs
+++ b/src/TemplateGen.Core/Services/NumberingDefinitionsGenerator.cs
@@ -52,7 +52,7 @@ public class NumberingDefinitionsGenerator
                 foreach (var listConfig in config.ListNumbering.NumberedLists)
                 {
                      sb.Append(CreateListAbstractNumXml(listConfig, abstractNumIdCounter, true));
-                     sb.Append($@"<w:num w:numId=""{abstractNumIdCounter}"" xmlns:w=""{W_NAMESPACE}""><w:abstractNumId w:val=""{abstractNumIdCounter}"" /></w:num>");
+                     sb.Append($@"<w:num w:numId=""{abstractNumIdCounter}"" xmlns:w=""{WordNamespace}""><w:abstractNumId w:val=""{abstractNumIdCounter}"" /></w:num>");
                      abstractNumIdCounter++;
                 }
             }
@@ -62,7 +62,6 @@ public class NumberingDefinitionsGenerator
                 foreach (var listConfig in config.ListNumbering.BulletLists)
                 {
                      sb.Append(CreateListAbstractNumXml(listConfig, abstractNumIdCounter, false));
-                     sb.Append($@"<w:num w:numId=""{abstractNumIdCounter}"" xmlns:w=""{W_NAMESPACE}""><w:abstractNumId w:val=""{abstractNumIdCounter}"" /></w:num>");
                      sb.Append($@"<w:num w:numId=""{abstractNumIdCounter}"" xmlns:w=""{WordNamespace}""><w:abstractNumId w:val=""{abstractNumIdCounter}"" /></w:num>");
                      abstractNumIdCounter++;
                 }
@@ -152,7 +151,7 @@ public class NumberingDefinitionsGenerator
     private string CreateListAbstractNumXml(ListConfig config, int id, bool isNumbered)
     {
         var sb = new System.Text.StringBuilder();
-        sb.Append($@"<w:abstractNum w:abstractNumId=""{id}"" xmlns:w=""{W_NAMESPACE}"">");
+        sb.Append($@"<w:abstractNum w:abstractNumId=""{id}"" xmlns:w=""{WordNamespace}"">");
         sb.Append(@"<w:multiLevelType w:val=""hybridMultilevel"" />");
         
         sb.Append(@"<w:lvl w:ilvl=""0"">");


### PR DESCRIPTION
### Motivation
- Corregir la generación de definiciones de numeración que estaba usando una constante de namespace incorrecta y produciendo entradas duplicadas en listas con viñetas.
- Evitar que `numbering.xml` generado tenga elementos `<w:num>` con namespace inválido o duplicados que puedan romper la apertura/uso en Word.

### Description
- Actualiza `src/TemplateGen.Core/Services/NumberingDefinitionsGenerator.cs` para usar la constante `WordNamespace` en todas las emisiones de `<w:num>` y `<w:abstractNum>` en lugar de la identificador erróneo `W_NAMESPACE`.
- Elimina la inserción duplicada de la entrada `<w:num>` para listas con viñetas y unifica la creación de `num` tras generar cada `abstractNum`.
- Mantiene la generación de XML en `Numbering` mediante `InnerXml` y la construcción de `abstractNum`/`num` con el namespace correcto.

### Testing
- No se ejecutaron tests automatizados tras este cambio.
- Antes del parche, los logs de build mostraban errores de compilación en otros módulos (CLI y `SchemaValidator`) que no se modificaron aquí, por lo que se recomienda ejecutar `dotnet build` y `dotnet test` en CI para validar el conjunto completo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956cc90878483229c68d07aa55904ca)